### PR TITLE
Allow unlocking when not locked

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -28,7 +28,7 @@ def cmd_start(arguments, config):
 def cmd_stop(arguments, config):
     state = get_state()
     if state["running"]:
-        if not lock.is_unlock_allowed(state):
+        if lock.is_locked() and not lock.is_unlock_allowed(state):
             print("This session is locked. You can not stop it.")
             return
         apply_backup()

--- a/src/lock.py
+++ b/src/lock.py
@@ -25,6 +25,8 @@ def is_locked():
 
 
 def is_unlock_allowed(state):
+    if not is_locked():
+        return True
     can_be_open_after = parser.parse(state["lock"]["locked_since"]) + timedelta(seconds=state["lock"]["locked_for"])
     return datetime.now() > can_be_open_after
 

--- a/src/lock.py
+++ b/src/lock.py
@@ -25,8 +25,6 @@ def is_locked():
 
 
 def is_unlock_allowed(state):
-    if not is_locked():
-        return True
     can_be_open_after = parser.parse(state["lock"]["locked_since"]) + timedelta(seconds=state["lock"]["locked_for"])
     return datetime.now() > can_be_open_after
 


### PR DESCRIPTION
Add check that lock is locked before asking whether it can be unlocked. 

I am not sure what is the intended behavior of `lock.is_unlock_allowed` when the lock is not locked so please change it if you feel like.

Stopping session now works even when there is no sensible value set for `locked_since` so this solves [this issue](https://github.com/yagarea/Stopro/issues/7).